### PR TITLE
API Returns Request with Authors

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -22,7 +22,7 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = authorize Article.find(params[:id])
-    render json: { article: article }, include: :authors
+    render json: { article: article }, include: [:authors]
   end
 
   private

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -22,7 +22,7 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = authorize Article.find(params[:id])
-    render json: { article: article }, include: [:authors]
+    render json: { article: article }, include: :authors
   end
 
   private

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -3,7 +3,7 @@ class Api::ArticlesController < ApplicationController
   def index
     articles = Article.get_published_articles(params[:category_name])
     if articles.any?
-      render json: { articles: articles }
+      render json: { articles: articles }, include: :authors
     else
       render json: { message: 'There are no articles in the database' }, status: 404
     end
@@ -22,7 +22,7 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = authorize Article.find(params[:id])
-    render json: { article: article }
+    render json: { article: article }, include: :authors
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,8 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :lede, :body, :category_name
   belongs_to :category
-  has_and_belongs_to_many :authors, class_name: 'User', join_table: 'articles_authors', association_foreign_key: 'author_id'
+  has_and_belongs_to_many :authors, class_name: 'User', join_table: 'articles_authors',
+                                    association_foreign_key: 'author_id'
 
   def self.get_published_articles(category_name)
     articles_published = Article.where(published: true)
@@ -10,9 +11,5 @@ class Article < ApplicationRecord
     else
       articles_published
     end
-  end
-
-  def date_published
-    attributes['updated_at'].strftime('%D')
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,4 +11,8 @@ class Article < ApplicationRecord
       articles_published
     end
   end
+
+  def date_published
+    attributes['updated_at'].strftime('%D')
+  end
 end

--- a/spec/requests/api/article_show_spec.rb
+++ b/spec/requests/api/article_show_spec.rb
@@ -29,6 +29,11 @@ describe 'GET api/articles/:id', type: :request do
     it 'is expected to return the author of the article' do
       expect(response_json['article']['authors'].last['name']).to eq journalist.name
     end
+
+    it 'is expected to return the date in a workable format' do
+      expect(response_json['article']['date']).to eq '24/10/21'
+    end
+    
   end
 
   describe 'unsuccessful, when the requested article does not exist in the database' do

--- a/spec/requests/api/article_show_spec.rb
+++ b/spec/requests/api/article_show_spec.rb
@@ -1,10 +1,11 @@
 describe 'GET api/articles/:id', type: :request do
   subject { response }
   let(:user) { create(:user) }
+  let(:journalist) { create(:journalist) }
   let(:credentials) { user.create_new_auth_token }
 
   describe 'successful, when the requested article exists in the database' do
-    let!(:article) { create(:article) }
+    let!(:article) { create(:article, authors: [journalist]) }
 
     before do
       get "/api/articles/#{article.id}",
@@ -23,6 +24,10 @@ describe 'GET api/articles/:id', type: :request do
 
     it 'is expected to return an article with the body included' do
       expect(response_json['article']['body']).to eq 'MyBody'
+    end
+
+    it 'is expected to return the author of the article' do
+      expect(response_json['articles'].last['authors']).to eq 'Some name'
     end
   end
 

--- a/spec/requests/api/article_show_spec.rb
+++ b/spec/requests/api/article_show_spec.rb
@@ -27,7 +27,7 @@ describe 'GET api/articles/:id', type: :request do
     end
 
     it 'is expected to return the author of the article' do
-      expect(response_json['articles'].last['authors']).to eq 'Some name'
+      expect(response_json['article']['authors'].last['name']).to eq journalist.name
     end
   end
 

--- a/spec/requests/api/article_show_spec.rb
+++ b/spec/requests/api/article_show_spec.rb
@@ -29,11 +29,6 @@ describe 'GET api/articles/:id', type: :request do
     it 'is expected to return the author of the article' do
       expect(response_json['article']['authors'].last['name']).to eq journalist.name
     end
-
-    it 'is expected to return the date in a workable format' do
-      expect(response_json['article']['date']).to eq '24/10/21'
-    end
-    
   end
 
   describe 'unsuccessful, when the requested article does not exist in the database' do

--- a/spec/requests/api/articles_index_spec.rb
+++ b/spec/requests/api/articles_index_spec.rb
@@ -2,10 +2,11 @@ RSpec.describe 'GET /api/articles', type: :request do
   subject { response }
 
   describe 'when there are some article in the database' do
+    let(:journalist) { create(:journalist) }
     let(:category) { create(:category, name: 'Tech') }
     let!(:article_1) { create(:article, category_id: category.id, category_name: category.name) }
     let!(:article_2) { create(:article, category_id: category.id, category_name: category.name) }
-    let!(:article_3) { create(:article) }
+    let!(:article_3) { create(:article, authors: [journalist]) }
 
     describe 'searching for all articles' do
       before do
@@ -23,6 +24,10 @@ RSpec.describe 'GET /api/articles', type: :request do
 
       it 'is expected to return an article with the published status true' do
         expect(response_json['articles'].last['published']).to eq true
+      end
+
+      it 'is expected to return the author of the article' do
+        expect(response_json['articles'].last['authors'].last['name']).to eq journalist.name
       end
     end
 


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/179968422

### User Story
```
As an API
In order to furnish my clients with information about who wrote the articles
I would like to include authors in my responses
```

### Tasks
- Modify `articles_controller` show action to return authors with `show` action
- Modify `articles_controller` to return authors with `index` action
NB: This chore also creates corresponding tests in `articles_index_spec` and `article_show_spec` (see screenshots


### Screenshots
![image](https://user-images.githubusercontent.com/31871856/138610654-0e1c3b69-2054-433a-b4b0-b82e1fdbc8a5.png)
