### PR TITLE
WIP API returns article author names as a sentence

### DIFF
--- a/app/serializers/articles/index_serializer.rb
+++ b/app/serializers/articles/index_serializer.rb
@@ -1,6 +1,10 @@
 class Articles::IndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lede, :updated_at, :published
+  attributes :id, :title, :lede, :updated_at, :published, :authors_as_sentence
 
   belongs_to :category, serializer: Categories::IndexSerializer
   has_many :authors, serializer: Users::AuthorsIndexSerializer
+
+  def authors_as_sentence
+    object.authors.pluck(:name).to_sentence
+  end
 end

--- a/spec/requests/api/articles_index_spec.rb
+++ b/spec/requests/api/articles_index_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'GET /api/articles', type: :request do
       end
 
       it 'is expected to return the author of the article' do
-        binding.pry
         expect(response_json['articles'].last['authors_as_sentence']).to eq journalist.name
       end
     end

--- a/spec/requests/api/articles_index_spec.rb
+++ b/spec/requests/api/articles_index_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe 'GET /api/articles', type: :request do
       end
 
       it 'is expected to return the author of the article' do
-        expect(response_json['articles'].last['authors'].last['name']).to eq journalist.name
+        binding.pry
+        expect(response_json['articles'].last['authors_as_sentence']).to eq journalist.name
       end
     end
 


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/180146862

```
As an API
In order to remove complexity from the frontend
I would like to return article authors as a sentence
```
### Tasks

### Screenshots
