### PR TITLE
API returns image in its json response

### DIFF
--- a/app/serializers/articles/index_serializer.rb
+++ b/app/serializers/articles/index_serializer.rb
@@ -1,6 +1,15 @@
 class Articles::IndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lede, :updated_at, :published
+  include Rails.application.routes.url_helpers
+  attributes :id, :title, :lede, :updated_at, :published, :image
 
   belongs_to :category, serializer: Categories::IndexSerializer
   has_many :authors, serializer: Users::AuthorsIndexSerializer
+
+  def image
+    if Rails.env.test?
+      rails_blob_path(object.image, only_path: true)
+    else
+      object.image.service_url(expires_in: 30.minutes)
+    end
+  end
 end

--- a/app/serializers/articles/show_serializer.rb
+++ b/app/serializers/articles/show_serializer.rb
@@ -1,6 +1,15 @@
 class Articles::ShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :lede, :body, :updated_at
+  include Rails.application.routes.url_helpers
+  attributes :id, :title, :lede, :body, :updated_at, :image
 
   belongs_to :category, serializer: Categories::IndexSerializer
   has_many :authors, serializer: Users::AuthorsIndexSerializer
+
+  def image
+    if Rails.env.test?
+      rails_blob_path(object.image, only_path: true)
+    else
+      object.image.service_url(expires_in: 30.minutes)
+    end
+  end
 end

--- a/spec/requests/api/article_show_spec.rb
+++ b/spec/requests/api/article_show_spec.rb
@@ -29,6 +29,11 @@ describe 'GET api/articles/:id', type: :request do
     it 'is expected to return the author of the article' do
       expect(response_json['article']['authors'].last['name']).to eq journalist.name
     end
+
+    it 'is expected to return an image with the article' do
+      expect(response_json['article']).to include 'image'
+    end
+    
   end
 
   describe 'unsuccessful, when the requested article does not exist in the database' do

--- a/spec/requests/api/articles_index_spec.rb
+++ b/spec/requests/api/articles_index_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe 'GET /api/articles', type: :request do
       it 'is expected to return the author of the article' do
         expect(response_json['articles'].last['authors'].last['name']).to eq journalist.name
       end
+
+      it 'is expected to return an image with the article' do
+        binding.pry
+        expect(response_json['articles'].last).to include 'image'
+      end
+      
     end
 
     describe 'search for articles by categories' do

--- a/spec/requests/api/articles_index_spec.rb
+++ b/spec/requests/api/articles_index_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'GET /api/articles', type: :request do
       end
 
       it 'is expected to return an image with the article' do
-        binding.pry
         expect(response_json['articles'].last).to include 'image'
       end
       

--- a/spec/serializers/index_serializer_spec.rb
+++ b/spec/serializers/index_serializer_spec.rb
@@ -20,7 +20,7 @@ describe Articles::IndexSerializer, type: :serializer do
   end
 
   it 'is expected to have a specific structure' do
-    expect(subject["articles"].last).to match(
+    expect(subject['articles'].last).to match(
       {
         'id' => an_instance_of(Integer),
         'title' => an_instance_of(String),
@@ -32,7 +32,8 @@ describe Articles::IndexSerializer, type: :serializer do
           'id' => an_instance_of(Integer),
           'name' => an_instance_of(String)
         },
-        'authors' => an_instance_of(Array)
+        'authors' => an_instance_of(Array),
+        'image' => an_instance_of(String)
       }
     )
   end

--- a/spec/serializers/index_serializer_spec.rb
+++ b/spec/serializers/index_serializer_spec.rb
@@ -15,7 +15,7 @@ describe Articles::IndexSerializer, type: :serializer do
   end
 
   it 'is expected to contain relevant keys' do
-    expected_keys = %w[id title lede updated_at published category authors]
+    expected_keys = %w[id title lede updated_at published image category authors]
     expect(subject['articles'].last.keys).to match expected_keys
   end
 

--- a/spec/serializers/show_serializer_spec.rb
+++ b/spec/serializers/show_serializer_spec.rb
@@ -14,7 +14,7 @@ describe Articles::ShowSerializer, type: :serializer do
   end
 
   it 'is expected to contain relevant keys' do
-    expected_keys = %w[id title lede body updated_at category authors]
+    expected_keys = %w[id title lede body updated_at image category authors]
     expect(subject['article'].keys).to match expected_keys
   end
 
@@ -31,7 +31,8 @@ describe Articles::ShowSerializer, type: :serializer do
           'id' => an_instance_of(Integer),
           'name' => an_instance_of(String)
         },
-        'authors' => an_instance_of(Array)
+        'authors' => an_instance_of(Array),
+        'image' => an_instance_of(String)
       }
     )
   end


### PR DESCRIPTION
Link to PT: https://www.pivotaltracker.com/story/show/180153850

### User Story
```
As an API
In order to furnish my frontends with images
I would like to return images when queried
```
### Tasks
- Create spec to see if `index` action returns image
- Create spec to see if `show` action returns image
- Implement serializer including image
- Fix serializer specs to reflect changes

### Screenshot
![image](https://user-images.githubusercontent.com/31871856/139741576-2bfc45de-cb08-4fcc-bfe2-91a8de83a288.png)
